### PR TITLE
Error logging in validator

### DIFF
--- a/lib/epiHiperValidator.js
+++ b/lib/epiHiperValidator.js
@@ -87,11 +87,11 @@ class EpiHiperValidator {
     try {
       file = this.resolvePath(file, relativeTo);
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
 
     if (!fs.existsSync(file)) {
-      console.log('File: ' + file + ' not found');
+      console.error('File: ' + file + ' not found');
       return {};
     }
 
@@ -106,7 +106,7 @@ class EpiHiperValidator {
         RawData = fs.readFileSync(file);
         Instance = JSON.parse(RawData);
       } catch (err) {
-        console.log('File: ' + file + ' does not contain valid JSON.');
+        console.error('File: ' + file + ' does not contain valid JSON.');
         return {};
       }
     }
@@ -126,6 +126,10 @@ class EpiHiperValidator {
   async processFile(validate, file, relativeTo) {
     const Instance = await this.load(file, relativeTo);
     const success = await validate(Instance);
+
+    if (!success){
+      console.error("Validation failed for '" + file + "'");
+    }
 
     return success;
   }
@@ -169,7 +173,7 @@ class EpiHiperValidator {
     const validate = this.ajv.getSchema('file://./' + Schema);
 
     if (typeof validate === 'undefined') {
-      console.log('Schema: ' + this.getSchemaURI(instance) + ' not found.');
+      console.error('Schema: ' + this.getSchemaURI(instance) + ' not found.');
       success = false;
     }
 
@@ -177,8 +181,8 @@ class EpiHiperValidator {
       const valid = validate(instance);
 
       if (!valid) {
-        console.log('File: ' + instance.__path + ' invalid');
-        console.log(validate.errors);
+        console.error('File: ' + instance.__path + ' invalid');
+        console.error(validate.errors);
         success = false;
       } else {
         console.log('File: ' + instance.__path + ' valid');
@@ -208,13 +212,13 @@ class EpiHiperValidator {
     const Rules = this.rules[RulesFile];
 
     if (typeof Rules === 'undefined') {
-      console.log('File: ' + instance.__path + ' no rules provided');
+      console.error('File: ' + instance.__path + ' no rules provided');
     } else {
       const Report = this.jsontron.JSONTRON.validate(instance, Rules);
 
       if (Report.finalValidationReport.length) {
-        console.log('File: ' + instance.__path + ' invalid');
-        console.log(Report.finalValidationReport);
+        console.error('File: ' + instance.__path + ' invalid');
+        console.error(Report.finalValidationReport);
         success = false;
       } else {
         console.log('File: ' + instance.__path + ' valid');


### PR DESCRIPTION
This patch does two things:
1. Changes console.log to console.error when and error is being logged.  This will just send things to stderr and make it easier to isolate what is wrong.
2. When validation fails, add a simple log that says Validation Failed for 'FILENAME'.  In the case where a file with "{}" as contents is provided (i.e., with no $schema or epihiperSchema), the validation will fail, but will just say there is no schema.  It doesn't say what has no schema.  This will end up logging that.

You could easily argue against #1 and I would be fine with it.  I would appreciate leaving in #2 (modified based on the decision in #1).